### PR TITLE
ローカル採点がJupyterで動くようになった

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+BASE_PATH=Autograding/.model/7231000021-

--- a/.grading.py
+++ b/.grading.py
@@ -1,0 +1,34 @@
+import os
+import subprocess
+import sys
+from pathlib import Path, PurePath
+
+# python-dotenvがインストールされていなければインストール
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "python-dotenv"])
+    from dotenv import load_dotenv
+
+# .grading.py の絶対パスを取得
+script_path = Path(__file__).resolve()
+env_path = script_path.parent / '.env'
+
+# .env ファイルを読み込む
+load_dotenv(env_path)
+# grading.py を実行
+base_path = os.getenv('BASE_PATH')
+
+# 引数からモデルのパスを取得
+model_path = sys.argv[1] if len(sys.argv) > 1 else ''
+
+# ノートブック自身のパスを取得
+student_notebook_path = model_path.split('/')[-1]
+
+result = subprocess.run(['python3', 'Autograding/grading.py', '--model', str(base_path) + str(model_path), '--student', str(student_notebook_path)], capture_output=True, text=True)
+
+# 採点結果を表示
+print(result.stdout)
+
+# エラーメッセージを表示
+print(result.stderr)

--- a/grading.py
+++ b/grading.py
@@ -43,7 +43,7 @@ def batch_grading(answer_dir_path: str, submitted_dir_path: str) -> None:
             print(f"エラー: 解答モデルが見つからない (ファイル名: {assignment_name})")
             continue
 
-        student_notebook = StudentNotebook(student_path, model_ans, mode="batch")
+        student_notebook = StudentNotebook(student_path, model_ans, is_local=False)
         score = student_notebook.grade()
         print(f"{student_notebook.student_name} {model_name}のスコア: {score}")
 
@@ -55,9 +55,8 @@ def local_grading(model_ans_path: str, student_path: str) -> None:
     model_name = model_ans_path.stem
     model_ans = load_model_ans(model_ans_path)
 
-    student_notebook = StudentNotebook(student_path, model_ans, mode="local")
+    student_notebook = StudentNotebook(student_path, model_ans)
     score = student_notebook.grade()
-    print(score)
 
 def main():
     parser = argparse.ArgumentParser(description='Grading script.')


### PR DESCRIPTION
マークダウンで採点結果を表示しようとマークダウンセルを追加、上書きするとJupyterでファイルが開けなくなるため、コードセルでの出力に変更した。
実行コマンドから、模範解答の隠しファイルが見つからないように環境変数とローカル採点実行ファイルを追加した。